### PR TITLE
Fix new_api client initialization

### DIFF
--- a/new_api/api_client.py
+++ b/new_api/api_client.py
@@ -5,8 +5,18 @@ class LightspeedAPIClient:
     API_BASE_URL = f"https://{os.environ.get('LIGHTSPEED_STORE')}.retail.api.lightspeedapp.app/api"
     API_KEY = os.environ.get('LIGHTSPEED_TOKEN')
 
-    def __init__(self, api_key: str):
-        self.api_key = api_key
+    def __init__(self, api_key: str | None = None):
+        """Create a new API client.
+
+        Parameters
+        ----------
+        api_key:
+            Optional API key to use for authentication. If not provided the
+            ``LIGHTSPEED_TOKEN`` environment variable will be used.  This makes
+            the client easier to configure for simple scripts.
+        """
+
+        self.api_key = api_key or self.API_KEY
         self.headers = {
             'Authorization': f'Bearer {self.api_key}',
             'Content-Type': 'application/json'

--- a/new_api/main.py
+++ b/new_api/main.py
@@ -1,14 +1,19 @@
-from api_client import get_brands, get_suppliers, get_categories, create_product
+"""Example script demonstrating usage of the API client."""
+
+from api_client import LightspeedAPIClient
 from lookups import BrandLookup, SupplierLookup, CategoryLookup
 from models import Product
 import requests
 
 if __name__ == "__main__":
     try:
+        # Create the API client using the token from the environment by default
+        client = LightspeedAPIClient()
+
         # Initialize lookup tables
-        brands_data = get_brands()
-        suppliers_data = get_suppliers()
-        categories_data = get_categories()
+        brands_data = client.get_brands()
+        suppliers_data = client.get_suppliers()
+        categories_data = client.get_categories()
 
         brands_lookup = BrandLookup(brands_data)
         suppliers_lookup = SupplierLookup(suppliers_data)
@@ -30,7 +35,7 @@ if __name__ == "__main__":
         }
         
         product = Product(**product_data)
-        created_product = create_product(product.dict())
+        created_product = client.create_product(product.dict())
         print("Product created successfully:", created_product)
         
     except requests.HTTPError as e:


### PR DESCRIPTION
## Summary
- fix the `LightspeedAPIClient` constructor so it falls back to the `LIGHTSPEED_TOKEN` env var
- update `new_api/main.py` to use the client instance instead of nonexistent functions

## Testing
- `python3 -m py_compile new_api/*.py`
- `python3 new_api/main.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687bbdb3b72c8332be8be4861be0222d