### PR TITLE
Introduce runtime lookup setup for Product model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ LightspeedPyAPI/
 ├── new_api/                 # Experimental client/models
 │   ├── api_client.py        # Minimal API wrapper
 │   ├── lookups.py           # Lookup classes for names ↔ IDs
+│   ├── lookups_runtime.py   # Runtime lookup initialization
 │   ├── main.py              # Example product creation script
 │   └── models.py            # Pydantic models for Product/Variant
 ├── CheckExisting.py, OrderProduct.py, etc.
@@ -33,7 +34,7 @@ class LightspeedAPIClient:
    - `Sync.py` contains `sync_data()` which fetches paginated data from Lightspeed, processes it, and updates the local DB.
 
 2. **new_api/**
-   - `models.py` uses Pydantic to model product data and to convert friendly names to IDs via lookup tables.
+   - `models.py` uses Pydantic to model product data and to convert friendly names to IDs via lookup tables. Lookups are loaded at runtime by `lookups_runtime.setup()`.
    - `api_client.py` is a lightweight wrapper around Lightspeed endpoints.
    - `main.py` demonstrates loading lookups and creating a product with variants.
 

--- a/new_api/lookups_runtime.py
+++ b/new_api/lookups_runtime.py
@@ -1,0 +1,24 @@
+"""Runtime lookup initialization for converting names to IDs."""
+
+from typing import Optional
+from .lookups import BrandLookup, SupplierLookup, CategoryLookup
+from .api_client import LightspeedAPIClient
+
+# Module-level lookup instances; may remain ``None`` if setup() hasn't been called
+brand_lookup: Optional[BrandLookup] = None
+supplier_lookup: Optional[SupplierLookup] = None
+category_lookup: Optional[CategoryLookup] = None
+
+
+def setup(client: LightspeedAPIClient) -> None:
+    """Populate lookup tables using the given API client."""
+    global brand_lookup, supplier_lookup, category_lookup
+
+    brands_data = client.get_brands()
+    suppliers_data = client.get_suppliers()
+    categories_data = client.get_categories()
+
+    brand_lookup = BrandLookup(brands_data)
+    supplier_lookup = SupplierLookup(suppliers_data)
+    category_lookup = CategoryLookup(categories_data)
+

--- a/new_api/main.py
+++ b/new_api/main.py
@@ -1,8 +1,8 @@
 """Example script demonstrating usage of the API client."""
 
 from new_api.api_client import LightspeedAPIClient
-from new_api.lookups import BrandLookup, SupplierLookup, CategoryLookup
 from new_api.models import Product
+from new_api.lookups_runtime import setup
 import requests
 
 if __name__ == "__main__":
@@ -10,14 +10,8 @@ if __name__ == "__main__":
         # Create the API client using the token from the environment by default
         client = LightspeedAPIClient()
 
-        # Initialize lookup tables
-        brands_data = client.get_brands()
-        suppliers_data = client.get_suppliers()
-        categories_data = client.get_categories()
-
-        brands_lookup = BrandLookup(brands_data)
-        suppliers_lookup = SupplierLookup(suppliers_data)
-        categories_lookup = CategoryLookup(categories_data)
+        # Initialize lookup tables for runtime conversion
+        setup(client)
         
         # Example product data
         product_data = {
@@ -34,12 +28,7 @@ if __name__ == "__main__":
             "custom_fields": {"material": "cotton"}
         }
         
-        product = Product(
-            **product_data,
-            brands_lookup=brands_lookup,
-            suppliers_lookup=suppliers_lookup,
-            categories_lookup=categories_lookup,
-        )
+        product = Product(**product_data)
         created_product = client.create_product(product.dict())
         print("Product created successfully:", created_product)
         

--- a/new_api/models.py
+++ b/new_api/models.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, root_validator
 from typing import List, Optional, Union
 
+from .lookups_runtime import brand_lookup, supplier_lookup, category_lookup
+
 class VariantAttributes(BaseModel):
     size: Optional[str]
     color: Optional[str]
@@ -26,16 +28,22 @@ class Product(BaseModel):
 
     @root_validator(pre=True)
     def convert_names_to_ids(cls, values):
-        brands_lookup = values.pop('brands_lookup', None)
-        suppliers_lookup = values.pop('suppliers_lookup', None)
-        categories_lookup = values.pop('categories_lookup', None)
+        brands_lookup = values.pop('brands_lookup', brand_lookup)
+        suppliers_lookup = values.pop('suppliers_lookup', supplier_lookup)
+        categories_lookup = values.pop('categories_lookup', category_lookup)
 
         if isinstance(values.get('brand'), str) and brands_lookup is not None:
-            values['brand'] = brands_lookup.get_id(values['brand'])
+            resolved = brands_lookup.get_id(values['brand'])
+            if resolved is not None:
+                values['brand'] = resolved
         if isinstance(values.get('supplier'), str) and suppliers_lookup is not None:
-            values['supplier'] = suppliers_lookup.get_id(values['supplier'])
+            resolved = suppliers_lookup.get_id(values['supplier'])
+            if resolved is not None:
+                values['supplier'] = resolved
         if isinstance(values.get('category'), str) and categories_lookup is not None:
-            values['category'] = categories_lookup.get_id(values.get('category'))
+            resolved = categories_lookup.get_id(values.get('category'))
+            if resolved is not None:
+                values['category'] = resolved
         return values
 
     class Config:


### PR DESCRIPTION
## Summary
- add `lookups_runtime.py` for shared Brand/Supplier/Category lookups
- update `Product` model to read lookups from the runtime module
- adjust `main.py` to call `lookups_runtime.setup`
- document the new module in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfd237d808332b0237880856cb340