### PR TITLE
Add pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pytest>=8.0
 
-requests
-pydantic
+requests>=2.31
+PyYAML>=6.0
+pydantic>=2,<3
+openpyxl>=3.1
 sqlalchemy

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,7 @@
+import importlib
+
+import pytest
+
+@pytest.mark.parametrize('module_name', ['requests', 'yaml', 'pydantic', 'openpyxl'])
+def test_import(module_name):
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- pin dependencies in requirements.txt
- add tests to check key imports succeed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `yaml` and `openpyxl`)*

------
https://chatgpt.com/codex/tasks/task_e_687c1315170c8332a83b9c852673acd8