### PR TITLE
Add supplier order parsing utilities

### DIFF
--- a/image_extractor.py
+++ b/image_extractor.py
@@ -1,0 +1,40 @@
+import subprocess
+import requests
+from pathlib import Path
+from typing import Iterable
+
+
+def pdf_to_text(pdf_path: str | Path) -> str:
+    """Return text extracted from ``pdf_path`` using ``pdftotext``."""
+    result = subprocess.run([
+        "pdftotext",
+        str(pdf_path),
+        "-",
+    ], check=True, capture_output=True, text=True)
+    return result.stdout
+
+
+def extract_images(pdf_path: str | Path, output_dir: str | Path) -> None:
+    """Extract images from ``pdf_path`` into ``output_dir`` using ``pdfimages``."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run([
+        "pdfimages",
+        "-j",
+        str(pdf_path),
+        str(output_dir / "image"),
+    ], check=True)
+
+
+def download_images(urls: Iterable[str], output_dir: str | Path) -> None:
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for url in urls:
+        filename = output_dir / Path(url).name
+        try:
+            resp = requests.get(url)
+            if resp.status_code == 200:
+                with open(filename, "wb") as f:
+                    f.write(resp.content)
+        except Exception:
+            pass

--- a/order_parser.py
+++ b/order_parser.py
@@ -1,0 +1,56 @@
+import csv
+import json
+import yaml
+from pathlib import Path
+from typing import List, Dict, Any
+
+from new_api.models import Product, Variant, VariantAttributes
+
+
+def load_definition(path: str | Path) -> Dict[str, Any]:
+    """Load a supplier definition from JSON or YAML."""
+    path = Path(path)
+    with open(path, "r", encoding="utf-8") as f:
+        if path.suffix in {".yaml", ".yml"}:
+            return yaml.safe_load(f)
+        return json.load(f)
+
+
+def _row_to_product(row: Dict[str, str], mapping: Dict[str, Any]) -> Product:
+    prod_map = mapping.get("product", {})
+    var_map = mapping.get("variants", {})
+
+    product_data = {
+        key: row.get(col, "") for key, col in prod_map.items()
+    }
+
+    attr_map = var_map.get("attributes", {})
+    attributes = {
+        attr: row.get(col, "") for attr, col in attr_map.items()
+    }
+
+    variant = Variant(
+        sku=row.get(var_map.get("sku", "sku"), ""),
+        price=float(row.get(var_map.get("price", "0"), 0) or 0),
+        inventory_level=int(row.get(var_map.get("inventory_level", "0"), 0) or 0),
+        attributes=VariantAttributes(**attributes),
+    )
+
+    product = Product(variants=[variant], **product_data)
+    return product
+
+
+def parse_csv(path: str | Path, mapping: Dict[str, Any]) -> List[Product]:
+    products: List[Product] = []
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            products.append(_row_to_product(row, mapping))
+    return products
+
+
+def parse_text(text: str, mapping: Dict[str, Any], delimiter: str = ",") -> List[Product]:
+    """Parse lines of delimited text (e.g., from pdftotext)."""
+    lines = [l for l in text.splitlines() if l.strip()]
+    reader = csv.DictReader(lines, delimiter=delimiter)
+    return [_row_to_product(row, mapping) for row in reader]

--- a/parse_orders.py
+++ b/parse_orders.py
@@ -1,0 +1,88 @@
+import argparse
+import csv
+import os
+from pathlib import Path
+from typing import List
+
+from order_parser import load_definition, parse_csv, parse_text
+from image_extractor import pdf_to_text, extract_images
+
+
+def products_to_rows(products) -> List[dict]:
+    rows = []
+    for p in products:
+        for v in p.variants:
+            rows.append({
+                "name": p.name,
+                "sku": v.sku,
+                "price": v.price,
+                "inventory": v.inventory_level,
+                "size": v.attributes.size,
+                "color": v.attributes.color,
+                "material": v.attributes.material,
+                "brand": p.brand,
+                "supplier": p.supplier,
+                "category": p.category,
+            })
+    return rows
+
+
+def write_output(rows: List[dict], out_path: Path) -> None:
+    if out_path.suffix == ".xlsx":
+        try:
+            from openpyxl import Workbook
+        except ImportError as exc:
+            raise RuntimeError("openpyxl is required for Excel output") from exc
+        wb = Workbook()
+        ws = wb.active
+        if rows:
+            ws.append(list(rows[0].keys()))
+        for r in rows:
+            ws.append(list(r.values()))
+        wb.save(out_path)
+    else:
+        with open(out_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Parse supplier orders")
+    parser.add_argument("definition", help="Path to supplier definition YAML/JSON")
+    parser.add_argument("order_file", help="CSV or PDF file")
+    parser.add_argument("--output", default="parsed_orders.csv", help="Output CSV/Excel file")
+    parser.add_argument("--extract-images", action="store_true", help="Extract images from PDF if provided")
+    parser.add_argument("--upload-images", action="store_true", help="Upload images using ImageUpdateFromCode")
+    args = parser.parse_args()
+
+    mapping = load_definition(args.definition)
+    order_path = Path(args.order_file)
+
+    if order_path.suffix.lower() == ".pdf":
+        text = pdf_to_text(order_path)
+        products = parse_text(text, mapping)
+        if args.extract_images:
+            extract_images(order_path, order_path.parent / "images")
+    else:
+        products = parse_csv(order_path, mapping)
+
+    rows = products_to_rows(products)
+    write_output(rows, Path(args.output))
+
+    if args.upload_images:
+        from ImageUpdateFromCode import LightspeedAPI, load_products_from_file, get_code_from_filename, get_product_id_supplier_code
+        token = os.environ.get("LIGHTSPEED_TOKEN")
+        store = os.environ.get("LIGHTSPEED_STORE")
+        api = LightspeedAPI(token, store)
+        product_lookup = load_products_from_file()
+        image_dir = Path(args.output).with_suffix("").parent / "images"
+        for img_path in image_dir.glob("*.jpg"):
+            code = get_code_from_filename(img_path.stem)
+            prod = get_product_id_supplier_code(product_lookup, code)
+            if prod:
+                api.upload_image(prod, img_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/supplier_definitions/example_supplier.yaml
+++ b/supplier_definitions/example_supplier.yaml
@@ -1,0 +1,13 @@
+product:
+  name: DESCRIPTION
+  brand: BRAND
+  category: CATEGORY
+  supplier: SUPPLIER
+variants:
+  sku: SKU
+  price: COST
+  inventory_level: QTY
+  attributes:
+    size: SIZE
+    color: COLOR
+    material: MATERIAL


### PR DESCRIPTION
## Summary
- map supplier field names in `supplier_definitions`
- parse supplier orders into the `Product` model with `order_parser.py`
- support text & image extraction with `image_extractor.py`
- provide `parse_orders.py` command line interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bea17f5b48332a44f033af405b3b0