### PR TITLE
Expand README with order parsing guide

### DIFF
--- a/new_api/models.py
+++ b/new_api/models.py
@@ -3,20 +3,29 @@ from typing import List, Optional, Union
 
 from .lookups_runtime import brand_lookup, supplier_lookup, category_lookup
 
+
 class VariantAttributes(BaseModel):
-    size: Optional[str]
-    color: Optional[str]
-    material: Optional[str]
+    """Optional attributes for a product variant."""
+
+    size: Optional[str] = None
+    color: Optional[str] = None
+    material: Optional[str] = None
+
 
 class Variant(BaseModel):
-    id: Optional[str]
+    """Representation of a variant row."""
+
+    id: Optional[str] = None
     sku: str
     price: float
     inventory_level: int
     attributes: VariantAttributes
 
+
 class Product(BaseModel):
-    id: Optional[str]
+    """Simplified product model used for order imports."""
+
+    id: Optional[str] = None
     name: str
     description: Optional[str] = None
     category: Union[str, Optional[str]] = None

--- a/parse_orders.py
+++ b/parse_orders.py
@@ -28,23 +28,12 @@ def products_to_rows(products) -> List[dict]:
 
 
 def write_output(rows: List[dict], out_path: Path) -> None:
-    if out_path.suffix == ".xlsx":
-        try:
-            from openpyxl import Workbook
-        except ImportError as exc:
-            raise RuntimeError("openpyxl is required for Excel output") from exc
-        wb = Workbook()
-        ws = wb.active
-        if rows:
-            ws.append(list(rows[0].keys()))
-        for r in rows:
-            ws.append(list(r.values()))
-        wb.save(out_path)
-    else:
-        with open(out_path, "w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
-            writer.writeheader()
-            writer.writerows(rows)
+    """Write parsed rows to a text CSV file."""
+
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- document supplier mapping files and order parsing workflow
- show image extraction & upload options for `parse_orders.py`
- fix optional `id` fields in `new_api.models`
- always write CSV output in `parse_orders`

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c246b62ec8332b5bd0baf2d9b7e70