### PR TITLE
Fix Pydantic v1 root_validator usage

### DIFF
--- a/new_api/models.py
+++ b/new_api/models.py
@@ -1,24 +1,26 @@
-from pydantic import BaseModel, root_validator
 from typing import List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from .lookups_runtime import brand_lookup, supplier_lookup, category_lookup
 
 
-""" class VariantAttributes(BaseModel):
+class VariantAttributes(BaseModel):
     """Optional attributes for a product variant."""
 
     size: Optional[str] = None
     color: Optional[str] = None
-    material: Optional[str] = None """
+    material: Optional[str] = None
 
 
-""" class Variant(BaseModel):
+class Variant(BaseModel):
     """Representation of a variant row."""
 
     id: Optional[str] = None
-    sku: str
-    price: float
-    attributes: VariantAttributes """
+    sku: Optional[str] = None
+    price: Optional[float] = None
+    inventory_level: int = 0
+    attributes: VariantAttributes
 
 
 class Product(BaseModel):
@@ -26,35 +28,35 @@ class Product(BaseModel):
 
     id: Optional[str] = None
     name: str
-    sku: str
+    sku: Optional[str] = None
     description: Optional[str] = None
-    category: Union[str, Optional[str]] = None
-    brand: Union[str, Optional[str]] = None
-    supplier: Union[str, Optional[str]] = None
-    price: float 
+    category: Union[str, None] = None
+    brand: Union[str, None] = None
+    supplier: Union[str, None] = None
+    price: Optional[float] = None
     tags: Optional[List[str]] = None
     supplier_code: Optional[str] = None
     custom_fields: Optional[dict] = None
+    variants: List[Variant] = []
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
     def convert_names_to_ids(cls, values):
-        brands_lookup = values.pop('brands_lookup', brand_lookup)
-        suppliers_lookup = values.pop('suppliers_lookup', supplier_lookup)
-        categories_lookup = values.pop('categories_lookup', category_lookup)
+        brands_lookup = values.pop("brands_lookup", brand_lookup)
+        suppliers_lookup = values.pop("suppliers_lookup", supplier_lookup)
+        categories_lookup = values.pop("categories_lookup", category_lookup)
 
-        if isinstance(values.get('brand'), str) and brands_lookup is not None:
-            resolved = brands_lookup.get_id(values['brand'])
+        if isinstance(values.get("brand"), str) and brands_lookup is not None:
+            resolved = brands_lookup.get_id(values["brand"])
             if resolved is not None:
-                values['brand'] = resolved
-        if isinstance(values.get('supplier'), str) and suppliers_lookup is not None:
-            resolved = suppliers_lookup.get_id(values['supplier'])
+                values["brand"] = resolved
+        if isinstance(values.get("supplier"), str) and suppliers_lookup is not None:
+            resolved = suppliers_lookup.get_id(values["supplier"])
             if resolved is not None:
-                values['supplier'] = resolved
-        if isinstance(values.get('category'), str) and categories_lookup is not None:
-            resolved = categories_lookup.get_id(values.get('category'))
+                values["supplier"] = resolved
+        if isinstance(values.get("category"), str) and categories_lookup is not None:
+            resolved = categories_lookup.get_id(values.get("category"))
             if resolved is not None:
-                values['category'] = resolved
+                values["category"] = resolved
         return values
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/order_parser.py
+++ b/order_parser.py
@@ -19,20 +19,18 @@ def load_definition(path: str | Path) -> Dict[str, Any]:
 def _row_to_product(row: Dict[str, str], mapping: Dict[str, Any]) -> Product:
     prod_map = mapping.get("product", {})
 
-    product_data = {
-        key: row.get(col, "") for key, col in prod_map.items()
-    }
-    """     attr_map = var_map.get("attributes", {})
-    attributes = {
-        attr: row.get(col, "") for attr, col in attr_map.items()
-    }
+    product_data = {key: row.get(col, "") for key, col in prod_map.items()}
+
+    var_map = mapping.get("variants", {})
+    attr_map = var_map.get("attributes", {})
+    attributes = {attr: row.get(col, "") for attr, col in attr_map.items()}
 
     variant = Variant(
         sku=row.get(var_map.get("sku", "sku"), ""),
         price=float(row.get(var_map.get("price", "0"), 0) or 0),
         inventory_level=int(row.get(var_map.get("inventory_level", "0"), 0) or 0),
         attributes=VariantAttributes(**attributes),
-    ) """    
+    )
 
     product = Product(variants=[variant], **product_data)
     return product


### PR DESCRIPTION
## Summary
- replace deprecated `root_validator` with Pydantic v2 `model_validator`
- implement `Variant` and `VariantAttributes` models
- parse variants correctly in `order_parser`

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886893c4fc48332a8e104675d60542a